### PR TITLE
using snprintf in time formatting

### DIFF
--- a/dbglog/detail/time.hpp
+++ b/dbglog/detail/time.hpp
@@ -29,6 +29,10 @@
 
 namespace dbglog { namespace detail {
 
+/** Time buffer for formatting date time[.subsecs]
+ *  64 bytes is more than enough, since the format take 27 chars at most:
+ *      "YYYY-MM-DD HH:MM:SS.ssssss\0"
+ */
 typedef char timebuffer[64];
 
 char* format_time(timebuffer &b, unsigned short precision = 0);

--- a/dbglog/detail/time.posix.cpp
+++ b/dbglog/detail/time.posix.cpp
@@ -45,7 +45,7 @@ char* format_time(timebuffer &b, unsigned short precision)
     auto end(b + written);
     left -= written;
 
-    // append sub-second fraction; snprintf writes up tu left characters
+    // append sub-second fraction; snprintf writes up to left characters
     // including final NUL
     switch (precision) {
     case 0: break;


### PR DESCRIPTION
Using `snprintf` instead of `sprintf` to prevent compiler warnings.

The code is fortified against truncated output, however the buffer is large enough (64 chars) that this should never happen since the output string is 27 chars long  (including final NUL char).
